### PR TITLE
Enforce morph class in Core User Model

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -65,4 +65,9 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return 'api';
     }
+
+    public function getMorphClass()
+    {
+        return config('auth.providers.users.model', self::class);
+    }
 }


### PR DESCRIPTION
getMorphClass() in Core User will always return either user model class configured in auth.providers or itself, so that all User models extending Core user model have same polymorphic relations