### PR TITLE
Solution for compatibility with Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "composer/composer": "^2.0",
     "laravel/framework": ">=7.0",
     "laravel/passport": ">=9.0",
-    "spatie/laravel-permission": "^3.18"
+    "spatie/laravel-permission": ">=3.18"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
There is incompatibility issue with Laravel 9. Solution is to set "spatie/laravel-permission": ">=3.18".