### PR TITLE
Return type to be added

### DIFF
--- a/src/Enums/BasicEnum.php
+++ b/src/Enums/BasicEnum.php
@@ -98,7 +98,7 @@ abstract class BasicEnum extends Enum
      * @return mixed
      * @throws \ReflectionException
      */
-    public static function getValue(string $name)
+    public static function getValue(string $name) :?string
     {
         if (self::isValidName($name)) {
             return parent::getValue(Str::upper($name));


### PR DESCRIPTION
- PHP Version: 8.1.0
- Laravel Version: 9.24

compose.json > require :

- "php": "^8.1",
- "escolalms/headless-h5p": "^0.4.3",
- "h5p/h5p-core": "dev-master",
- "h5p/h5p-editor": "dev-master",
- "laravel/framework": "^9.24",

## Description: 

Mentioned in [this issue](https://github.com/EscolaLMS/H5P/issues/145).

After running composer require `escolalms/headless-h5p command`, got this error on Laravel's `@php artisan package:discover --ansi` step

![image](https://user-images.githubusercontent.com/31011885/184818749-d5b34219-6a97-415f-be47-0f925f6e8972.png)

## Changes

Return type added to the function `Enums\BasicEnum::getValue` in order to avoid error 
